### PR TITLE
fix(mdx): add full width to image zoom button

### DIFF
--- a/src/app/components/mdx/image.tsx
+++ b/src/app/components/mdx/image.tsx
@@ -54,7 +54,7 @@ export function MdxImage({ alt, className, ...props }: MdxImageProps) {
     <>
       <button
         type="button"
-        className="group block cursor-zoom-in outline-none"
+        className="group block w-full cursor-zoom-in outline-none"
         onClick={() => setIsOpen(true)}
         aria-label={
           alt ? `Open image fullscreen: ${alt}` : "Open image fullscreen"


### PR DESCRIPTION
The button was not spanning the full width of its container, causing inconsistent click targets. Adding w-full ensures the entire image area is clickable for zooming.